### PR TITLE
Don't use default value for retention_period in test

### DIFF
--- a/sumologic/resource_sumologic_partition_test.go
+++ b/sumologic/resource_sumologic_partition_test.go
@@ -90,6 +90,7 @@ resource "sumologic_partition" "foo" {
     name = "terraform_acctest_%s"
     routing_expression = "_sourcecategory=*/Terraform"
     is_compliant = false
+    retention_period = 30
 }
 `, testName)
 }


### PR DESCRIPTION
Using default value for `retention_period` returns a response based on org. Replace it with an explicit value.