### PR TITLE
fix bug with redirect endpoint for prod

### DIFF
--- a/sumologic/provider.go
+++ b/sumologic/provider.go
@@ -81,7 +81,9 @@ func resolveRedirectURL(accessId string, accessKey string) (string, error) {
 	}
 	location := resp.Header.Get("location")
 	if location == "" {
-		return location, fmt.Errorf("location header not found")
+		// location header not found implies there was no redirect needed
+		// i.e, the desired environment is us1
+		return "https://api.sumologic.com/api/", nil
 	}
 	return strings.Split(location, "v1")[0], nil
 }


### PR DESCRIPTION
When neither environment nor base_url is set, we attempt to redirect to the correct deployment's endpoint by making the request to `prod` first, and reading from the `location` header, however if the access id/key are for the `prod` environment then the `location` header does not exist since there is no redirect needed.

Then in `providerConfigure` we set the default environment to `us2` (as per the documented default), which leads to an unauthorized error (`prod` access id/key with the `us2` endpoint).