### PR TITLE
Add support for CloudWatch metrics in sumologic polling source

### DIFF
--- a/sumologic/resource_sumologic_polling_source.go
+++ b/sumologic/resource_sumologic_polling_source.go
@@ -24,16 +24,13 @@ func resourceSumologicPollingSource() *schema.Resource {
 	pollingSource.Schema["scan_interval"] = &schema.Schema{
 		Type:     schema.TypeInt,
 		Required: true,
-		ForceNew: false,
 	}
 	pollingSource.Schema["paused"] = &schema.Schema{
 		Type:     schema.TypeBool,
 		Required: true,
-		ForceNew: false,
 	}
 	pollingSource.Schema["url"] = &schema.Schema{
 		Type:     schema.TypeString,
-		ForceNew: false,
 		Computed: true,
 	}
 	pollingSource.Schema["authentication"] = &schema.Schema{
@@ -52,17 +49,14 @@ func resourceSumologicPollingSource() *schema.Resource {
 				"access_key": {
 					Type:     schema.TypeString,
 					Optional: true,
-					ForceNew: false,
 				},
 				"secret_key": {
 					Type:     schema.TypeString,
 					Optional: true,
-					ForceNew: false,
 				},
 				"role_arn": {
 					Type:     schema.TypeString,
 					Optional: true,
-					ForceNew: false,
 				},
 			},
 		},
@@ -83,17 +77,14 @@ func resourceSumologicPollingSource() *schema.Resource {
 				"bucket_name": {
 					Type:     schema.TypeString,
 					Optional: true,
-					ForceNew: false,
 				},
 				"path_expression": {
 					Type:     schema.TypeString,
 					Optional: true,
-					ForceNew: false,
 				},
 				"limit_to_regions": {
 					Type:     schema.TypeList,
 					Optional: true,
-					ForceNew: false,
 					Elem: &schema.Schema{
 						Type: schema.TypeString,
 					},
@@ -101,7 +92,6 @@ func resourceSumologicPollingSource() *schema.Resource {
 				"limit_to_namespaces": {
 					Type:     schema.TypeList,
 					Optional: true,
-					ForceNew: false,
 					Elem: &schema.Schema{
 						Type: schema.TypeString,
 					},
@@ -110,23 +100,19 @@ func resourceSumologicPollingSource() *schema.Resource {
 				"tag_filters": {
 					Type:     schema.TypeList,
 					Optional: true,
-					ForceNew: false,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"type": {
 								Type:     schema.TypeString,
 								Optional: true,
-								ForceNew: false,
 							},
 							"namespace": {
 								Type:     schema.TypeString,
 								Optional: true,
-								ForceNew: false,
 							},
 							"tags": {
 								Type:     schema.TypeList,
 								Optional: true,
-								ForceNew: false,
 								Elem: &schema.Schema{
 									Type: schema.TypeString,
 								},

--- a/sumologic/sumologic_polling_source.go
+++ b/sumologic/sumologic_polling_source.go
@@ -32,9 +32,18 @@ type PollingAuthentication struct {
 }
 
 type PollingPath struct {
-	Type           string `json:"type"`
-	BucketName     string `json:"bucketName"`
-	PathExpression string `json:"pathExpression"`
+	Type              string      `json:"type"`
+	BucketName        string      `json:"bucketName,omitempty"`
+	PathExpression    string      `json:"pathExpression,omitempty"`
+	LimitToRegions    []string    `json:"limitToRegions,omitempty"`
+	LimitToNamespaces []string    `json:"limitToNamespaces,omitempty"`
+	TagFilters        []TagFilter `json:"tagFilters,omitempty"`
+}
+
+type TagFilter struct {
+	Type      string   `json:"type"`
+	Namespace string   `json:"namespace"`
+	Tags      []string `json:"tags"`
 }
 
 func (s *Client) CreatePollingSource(source PollingSource, collectorID int) (int, error) {


### PR DESCRIPTION
Sample TF File: 
```
provider "sumologic" {}

provider "aws" {}

resource "sumologic_collector" "collector" {
    name = "MyTFCollector"
}

locals {
  filters = [{
            "type" = "TagFilters"
            "namespace" = "All"
            "tags" = ["k3=v3"]
          },{
            "type" = "TagFilters"
            "namespace" = "AWS/Route53"
            "tags" = ["k1=v1"]
          },{
            "type" = "TagFilters"
            "namespace" = "AWS/S3"
            "tags" = ["k2=v2"]
          }]
}

resource "sumologic_polling_source" "terraform_cw_metrics" {
  name          = "Terraform CW Metrics"
  description   = "My description"
  category      = "aws/terraform_cw"
  content_type  = "AwsCloudWatch"
  scan_interval = 300000
  paused        = false
  collector_id  = "${sumologic_collector.collector.id}"

  authentication {
    type = "AWSRoleBasedAuthentication"
    role_arn = "xxxx"
  }

  path {
    type = "CloudWatchPath"
    limit_to_regions = ["us-west-2"]
    limit_to_namespaces = ["AWS/Route53","AWS/S3","customNamepace"]
  
    dynamic "tag_filters" {
    for_each = local.filters
    content{
      type = tag_filters.value.type
      namespace = tag_filters.value.namespace
      tags = tag_filters.value.tags
    }
    }  
  }
}
```