### PR TITLE
content/folder: use resource.StateChangeConf to improve job polling

### DIFF
--- a/sumologic/resource_sumologic_content.go
+++ b/sumologic/resource_sumologic_content.go
@@ -31,9 +31,9 @@ func resourceSumologicContent() *schema.Resource {
 			},
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Read:   schema.DefaultTimeout(time.Duration(1) * time.Minute),
-			Create: schema.DefaultTimeout(time.Duration(10) * time.Minute),
-			Delete: schema.DefaultTimeout(time.Duration(1) * time.Minute),
+			Read:   schema.DefaultTimeout(1 * time.Minute),
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(1 * time.Minute),
 		},
 	}
 }

--- a/sumologic/resource_sumologic_content_test.go
+++ b/sumologic/resource_sumologic_content_test.go
@@ -3,6 +3,7 @@ package sumologic
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -66,7 +67,7 @@ func testAccCheckContentExists(name string, content *Content, t *testing.T) reso
 
 		id := rs.Primary.ID
 		c := testAccProvider.Meta().(*Client)
-		newContent, err := c.GetContent(id)
+		newContent, err := c.GetContent(id, time.Minute)
 		if err != nil {
 			return fmt.Errorf("Content %s not found", id)
 		}
@@ -87,7 +88,7 @@ func testAccCheckContentAttributes(name string) resource.TestCheckFunc {
 func testAccCheckContentDestroy(content Content) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*Client)
-		_, err := client.GetContent(content.ID)
+		_, err := client.GetContent(content.ID, time.Minute)
 		if err == nil {
 			return fmt.Errorf("Content still exists")
 		}

--- a/sumologic/resource_sumologic_folder.go
+++ b/sumologic/resource_sumologic_folder.go
@@ -2,6 +2,7 @@ package sumologic
 
 import (
 	"log"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -32,6 +33,9 @@ func resourceSumologicFolder() *schema.Resource {
 				Required: true,
 				ForceNew: false,
 			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(time.Duration(1) * time.Minute),
 		},
 	}
 }
@@ -73,7 +77,7 @@ func resourceSumologicFolderDelete(d *schema.ResourceData, meta interface{}) err
 	log.Printf("Deleting Folder Id: %s", d.Id())
 	c := meta.(*Client)
 	log.Println("====End Folder Delete====")
-	return c.DeleteFolder(d.Id())
+	return c.DeleteFolder(d.Id(), d.Timeout(schema.TimeoutDelete))
 }
 
 func resourceSumologicFolderCreate(d *schema.ResourceData, meta interface{}) error {

--- a/sumologic/resource_sumologic_folder.go
+++ b/sumologic/resource_sumologic_folder.go
@@ -35,7 +35,7 @@ func resourceSumologicFolder() *schema.Resource {
 			},
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Delete: schema.DefaultTimeout(time.Duration(1) * time.Minute),
+			Delete: schema.DefaultTimeout(time.Minute),
 		},
 	}
 }

--- a/sumologic/sumologic_content.go
+++ b/sumologic/sumologic_content.go
@@ -222,6 +222,10 @@ func waitForJob(url string, timeout time.Duration, s *Client) error {
 			log.Println(status.Errors)
 			log.Println("====End Job Status Check====")
 
+			if status.Status == "failed" {
+				return status, status.Status, fmt.Errorf("job failed: %s", status.StatusMessage)
+			}
+
 			return status, status.Status, nil
 		},
 		Timeout:                   timeout,

--- a/sumologic/sumologic_content.go
+++ b/sumologic/sumologic_content.go
@@ -228,10 +228,9 @@ func waitForJob(url string, timeout time.Duration, s *Client) error {
 
 			return status, status.Status, nil
 		},
-		Timeout:                   timeout,
-		Delay:                     1 * time.Second,
-		MinTimeout:                1 * time.Second,
-		ContinuousTargetOccurence: 5,
+		Timeout:    timeout,
+		Delay:      1 * time.Second,
+		MinTimeout: 1 * time.Second,
 	}
 
 	_, err := conf.WaitForState()

--- a/sumologic/sumologic_content.go
+++ b/sumologic/sumologic_content.go
@@ -6,10 +6,12 @@ import (
 	"log"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
 //READ
-func (s *Client) GetContent(id string) (*Content, error) {
+func (s *Client) GetContent(id string, timeout time.Duration) (*Content, error) {
 	log.Println("####Begin GetContent####")
 
 	url := fmt.Sprintf("v2/content/%s/export", id)
@@ -41,18 +43,9 @@ func (s *Client) GetContent(id string) (*Content, error) {
 
 	//Ensure the job has completed before proceeding
 	log.Printf("Job Id: %s", id)
-	for {
-		jobStatus, err := checkJobStatus(url, s)
-		if err != nil {
-			log.Println("Error occurred during job status check.")
-			return nil, err
-		}
-		if jobStatus {
-			break
-		}
-
-		log.Printf("Sleeping for 1 second before retrying Job Status check...")
-		time.Sleep(1 * time.Second)
+	err = waitForJob(url, timeout, s)
+	if err != nil {
+		return nil, err
 	}
 
 	//Request the results of the job
@@ -88,7 +81,7 @@ func (s *Client) GetContent(id string) (*Content, error) {
 }
 
 //DELETE
-func (s *Client) DeleteContent(id string) error {
+func (s *Client) DeleteContent(id string, timeout time.Duration) error {
 	log.Println("####Begin DeleteContent####")
 
 	log.Printf("Deleting Content Id: %s", id)
@@ -116,27 +109,14 @@ func (s *Client) DeleteContent(id string) error {
 	url = fmt.Sprintf("v2/content/%s/delete/%s/status", id, jid.ID)
 	log.Printf("Content delete job status url: %s", url)
 
-	//Ensure the job has completed before proceeding
-	for {
-		jobStatus, err := checkJobStatus(url, s)
-		if err != nil {
-			log.Println("Error occurred during job status check.")
-			return err
-		}
-		if jobStatus {
-			break
-		}
-
-		log.Printf("Sleeping for 1 second before retrying Job Status check...")
-		time.Sleep(1 * time.Second)
-	}
+	waitForJob(url, timeout, s)
 
 	log.Println("####End DeleteContent####")
 	return err
 }
 
 //CREATE
-func (s *Client) CreateContent(content Content) (string, error) {
+func (s *Client) CreateContent(content Content, timeout time.Duration) (string, error) {
 	log.Println("####Begin CreateContent####")
 
 	url := fmt.Sprintf("v2/content/folders/%s/import", content.ParentId)
@@ -164,20 +144,7 @@ func (s *Client) CreateContent(content Content) (string, error) {
 	url = fmt.Sprintf("v2/content/folders/%s/import/%s/status", content.ParentId, jid.ID)
 	log.Printf("Create content job status url: %s", url)
 
-	//Ensure the job has completed before proceeding
-	for {
-		jobStatus, err := checkJobStatus(url, s)
-		if err != nil {
-			log.Println("Error occurred during job status check.")
-			return "", err
-		}
-		if jobStatus {
-			break
-		}
-
-		log.Printf("Sleeping for 1 second before retrying Job Status check...")
-		time.Sleep(1 * time.Second)
-	}
+	waitForJob(url, timeout, s)
 
 	log.Println("####Begin Folder Read####")
 	log.Printf("Looking up folder with ID: %s", content.ParentId)
@@ -227,37 +194,42 @@ func (s *Client) CreateContent(content Content) (string, error) {
 	return "", nil
 }
 
-func checkJobStatus(url string, s *Client) (bool, error) {
+func waitForJob(url string, timeout time.Duration, s *Client) error {
+	conf := &resource.StateChangeConf{
+		Pending: []string{
+			"InProgress",
+		},
+		Target: []string{
+			"Success",
+		},
+		Refresh: func() (interface{}, string, error) {
+			log.Println("====Start Job Status Check====")
 
-	log.Println("====Start Job Status Check====")
+			var status Status
+			b, _, err := s.Get(url)
+			if err != nil {
+				return nil, "", err
+			}
 
-	//check the status of the job
-	rawStatus, _, err := s.Get(url)
+			err = json.Unmarshal(b, &status)
+			if err != nil {
+				return nil, "", err
+			}
 
-	//If there were no errors during the request, proceed
-	if err != nil {
-		return false, err
+			log.Printf("Job Status: %s", status.Status)
+			log.Printf("Job Message: %s", status.StatusMessage)
+			log.Println("Job Errors:")
+			log.Println(status.Errors)
+			log.Println("====End Job Status Check====")
+
+			return status, status.Status, nil
+		},
+		Timeout:                   timeout,
+		Delay:                     1 * time.Second,
+		MinTimeout:                1 * time.Second,
+		ContinuousTargetOccurence: 5,
 	}
 
-	// Parse the Job Status message
-	var status Status
-	err = json.Unmarshal(rawStatus, &status)
-
-	//Exit here if there was an error parsing the json
-	if err != nil {
-		return false, err
-	}
-
-	log.Printf("Job Status: %s", status.Status)
-	log.Printf("Job Message: %s", status.StatusMessage)
-	log.Println("Job Errors:")
-	log.Println(status.Errors)
-	log.Println("====End Job Status Check====")
-
-	if status.Status == "Success" {
-		return true, nil
-	} else {
-		return false, nil
-	}
-
+	_, err := conf.WaitForState()
+	return err
 }

--- a/sumologic/sumologic_folder.go
+++ b/sumologic/sumologic_folder.go
@@ -36,7 +36,7 @@ func (s *Client) GetFolder(id string) (*Folder, error) {
 }
 
 //DELETE
-func (s *Client) DeleteFolder(id string) error {
+func (s *Client) DeleteFolder(id string, timeout time.Duration) error {
 	log.Println("####Begin DeleteFolder####")
 
 	log.Printf("Deleting Folder Id: %s", id)
@@ -64,41 +64,7 @@ func (s *Client) DeleteFolder(id string) error {
 	url = fmt.Sprintf("v2/content/%s/delete/%s/status", id, jid.ID)
 	log.Printf("Folder delete job status url: %s", url)
 
-	//Ensure the job has completed before proceeding
-	for {
-
-		log.Println("====Start Job Status Check====")
-
-		//check the status of the job
-		rawStatus, _, err := s.Get(url)
-
-		//If there were no errors during the request, proceed
-		if err != nil {
-			return err
-		}
-
-		// Parse the Job Status message
-		var status Status
-		err = json.Unmarshal(rawStatus, &status)
-
-		//Exit here if there was an error parsing the json
-		if err != nil {
-			return err
-		}
-
-		log.Printf("Job Status: %s", status.Status)
-		log.Printf("Job Message: %s", status.StatusMessage)
-		log.Println("Job Errors:")
-		log.Println(status.Errors)
-		log.Println("====End Job Status Check====")
-
-		if status.Status == "Success" {
-			break
-		}
-
-		log.Printf("Sleeping for 1 second before retrying Job Status check...")
-		time.Sleep(1 * time.Second)
-	}
+	waitForJob(url, timeout, s)
 
 	log.Println("####End DeleteFolder####")
 	return err

--- a/website/docs/r/content.html.markdown
+++ b/website/docs/r/content.html.markdown
@@ -64,6 +64,14 @@ The following arguments are supported:
 - `parent_id` - (Required) The identifier of the folder to import into. Identifiers from the Library in the Sumo user interface are provided in decimal format which is incompatible with Terraform. The identifier needs to be in hexadecimal format.
 - `config` - (Required) JSON block for the content to import.
 
+### Timeouts
+
+`sumologic_content` provides the following [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `read` - (Default `1 minute`) Used for waiting for the import job to be successful
+- `create` - (Default `10 minutes`) Used for waiting for the import job to be successful
+- `delete` - (Default `1 minute`) Used for waiting for the deletion job to be successful
+
 ## Attributes reference
 
 The following attributes are exported:

--- a/website/docs/r/folder.html.markdown
+++ b/website/docs/r/folder.html.markdown
@@ -27,6 +27,12 @@ The following arguments are supported:
 - `parent_id` - (Required) The ID of the folder in which you want to create the new folder.
 - `description` - (Optional) The description of the folder.
 
+### Timeouts
+
+`sumologic_folder` provides the following [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `delete` - (Default `1 minute`) Used for waiting for the deletion job to be successful
+
 Additional data provided in state
 
 - `created_at` - (Computed) When the folder was created.


### PR DESCRIPTION
This PR introduces  [`resource.StateChangeConf`](https://www.terraform.io/docs/extend/resources/retries-and-customizable-timeouts.html#statechangeconf) to help improve the reliability and messaging for library management resources with a job status API. 

It adds customizable timeouts for each resource/operation that has job polling and passes them to `StateChangeConf`, which provides:

* Handling of errors: previously, a "Failed" job resulted in an infinite loop. We observed this at @takescoop which is what brought me here. Now "Failed" is an unknown state, and will trigger an immediate error.
* Timeouts for jobs that don't progress: previously, an "InProgress" job that never became successful resulted in an infinite loop. We didn't observe this, but it's worth defending against anyway. 
* Backoff: previously, requests were issued every second. With backoff, far fewer requests will be sent for long-running jobs (hopefully reduces pressure on the rate limiter), with minimal delay for users.

`StateChangeConf` helps with readable logs/errors for debugging as well:

```
errors during refresh: timeout while waiting for state to become 'Success' (last state: 'InProgress', timeout: 1m0s)
```

## Acceptance Tests

```
$ TESTARGS="-run 'TestAcc(Content|Folder)'" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run 'TestAcc(Content|Folder)' -timeout 120m
?   	github.com/terraform-providers/terraform-provider-sumologic	[no test files]
=== RUN   TestAccContent_create
--- PASS: TestAccContent_create (35.05s)
=== RUN   TestAccContent_update
--- PASS: TestAccContent_update (67.27s)
=== RUN   TestAccFolder_create
--- PASS: TestAccFolder_create (7.73s)
=== RUN   TestAccFolder_update
--- PASS: TestAccFolder_update (9.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-sumologic/sumologic
```

## Questions

* Do these timeouts make sense? I'm guessing, but inside knowledge of the API behavior (e.g. 99% latency for jobs) would help inform the value 🙂.